### PR TITLE
fix: uppercase boolean and wrong condition in filters

### DIFF
--- a/src/Casdoor.Client/CasdoorClient.RoleApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.RoleApi.cs
@@ -22,7 +22,7 @@ public partial class CasdoorClient
     {
         var builder = new QueryMapBuilder().Add("owner", owner ?? _options.OrganizationName);
 
-        if (!string.IsNullOrEmpty(filterFieldName))
+        if (!string.IsNullOrEmpty(filterFieldName) && !string.IsNullOrEmpty(filterFieldValue))
         {
             builder.Add("field", filterFieldName);
             builder.Add("value", filterFieldValue);
@@ -39,7 +39,7 @@ public partial class CasdoorClient
     {
         var builder = new QueryMapBuilder().Add("owner", owner ?? _options.OrganizationName);
 
-        if (!string.IsNullOrEmpty(filterFieldName) || !string.IsNullOrEmpty(filterFieldValue))
+        if (!string.IsNullOrEmpty(filterFieldName) && !string.IsNullOrEmpty(filterFieldValue))
         {
             builder.Add("field", filterFieldName);
             builder.Add("value", filterFieldValue);

--- a/src/Casdoor.Client/CasdoorClient.UserApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.UserApi.cs
@@ -24,7 +24,7 @@ public partial class CasdoorClient
     {
         var builder = new QueryMapBuilder()
             .Add("owner", owner ?? _options.OrganizationName)
-            .Add("fillUserIdProvider", fillUserIdProvider ? "true" : "false");
+            .Add("fillUserIdProvider", fillUserIdProvider.ToString().ToLower());
 
         if (!string.IsNullOrEmpty(filterFieldName) && !string.IsNullOrEmpty(filterFieldValue))
         {
@@ -42,7 +42,7 @@ public partial class CasdoorClient
     {
         var builder = new QueryMapBuilder()
             .Add("owner", owner ?? _options.OrganizationName)
-            .Add("fillUserIdProvider", fillUserIdProvider ? "true" : "false");
+            .Add("fillUserIdProvider", fillUserIdProvider.ToString().ToLower());
 
         if (!string.IsNullOrEmpty(filterFieldName) && !string.IsNullOrEmpty(filterFieldValue))
         {

--- a/src/Casdoor.Client/CasdoorClient.UserApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.UserApi.cs
@@ -24,9 +24,9 @@ public partial class CasdoorClient
     {
         var builder = new QueryMapBuilder()
             .Add("owner", owner ?? _options.OrganizationName)
-            .Add("fillUserIdProvider", fillUserIdProvider.ToString());
+            .Add("fillUserIdProvider", fillUserIdProvider ? "true" : "false");
 
-        if (!string.IsNullOrEmpty(filterFieldName) || !string.IsNullOrEmpty(filterFieldValue))
+        if (!string.IsNullOrEmpty(filterFieldName) && !string.IsNullOrEmpty(filterFieldValue))
         {
             builder.Add("field", filterFieldName);
             builder.Add("value", filterFieldValue);
@@ -42,9 +42,9 @@ public partial class CasdoorClient
     {
         var builder = new QueryMapBuilder()
             .Add("owner", owner ?? _options.OrganizationName)
-            .Add("fillUserIdProvider", fillUserIdProvider.ToString());
+            .Add("fillUserIdProvider", fillUserIdProvider ? "true" : "false");
 
-        if (!string.IsNullOrEmpty(filterFieldName) || !string.IsNullOrEmpty(filterFieldValue))
+        if (!string.IsNullOrEmpty(filterFieldName) && !string.IsNullOrEmpty(filterFieldValue))
         {
             builder.Add("field", filterFieldName);
             builder.Add("value", filterFieldValue);


### PR DESCRIPTION
Оказывается это нужно было) Если использовать `fillUserIdProvider.ToString()`, true становится True, касгейт такое не читает "**Handler crashed with error strconv.Atoi: parsing "True": invalid syntax**"